### PR TITLE
Add an isResolved field to both Note and ConfusionMark entities along…

### DIFF
--- a/app/src/main/java/com/example/conwayying/query/data/QueryAppDatabase.java
+++ b/app/src/main/java/com/example/conwayying/query/data/QueryAppDatabase.java
@@ -18,7 +18,7 @@ import com.example.conwayying.query.data.entity.NoteDao;
  * Database for all Entities for the Query app
  */
 @Database(entities = {AcademicClass.class, Lecture.class, Note.class, ConfusionMark.class},
-    version = 5)
+    version = 6)
 public abstract class QueryAppDatabase extends RoomDatabase {
 
     public abstract AcademicClassDao getAcademicClassDao();

--- a/app/src/main/java/com/example/conwayying/query/data/QueryAppRepository.java
+++ b/app/src/main/java/com/example/conwayying/query/data/QueryAppRepository.java
@@ -1,6 +1,7 @@
 package com.example.conwayying.query.data;
 
 import android.app.Application;
+import android.util.Pair;
 
 import com.example.conwayying.query.data.entity.AcademicClass;
 import com.example.conwayying.query.data.entity.AcademicClassDao;
@@ -24,6 +25,14 @@ public class QueryAppRepository {
 
     public QueryAppRepository(Application application){
         QueryAppDatabase db = QueryAppDatabase.getDatabase(application);
+        mAcademicClassDao = db.getAcademicClassDao();
+        mLectureDao = db.getLectureDao();
+        mNoteDao = db.getNoteDao();
+        mConfusionMarkDao = db.getConfusionMarkDao();
+    }
+
+    // Constructor used for testing purposes only
+    public QueryAppRepository(QueryAppDatabase db){
         mAcademicClassDao = db.getAcademicClassDao();
         mLectureDao = db.getLectureDao();
         mNoteDao = db.getNoteDao();
@@ -88,6 +97,18 @@ public class QueryAppRepository {
     }
 
     /**
+     * @param classId Id of an AcademicClass
+     * @return All of the Notes for a given Lecture
+     */
+    public List<Note> getAllNotesForClass(int classId){
+        return mNoteDao.getAllNotesOfClass(classId);
+    }
+
+    /**
+     * @param noteId Id of a Note
+     * @return The Note with the specified id
+
+    /**
      * @param noteId Id of a Note
      * @return The Note with the specified id
      */
@@ -130,6 +151,94 @@ public class QueryAppRepository {
      */
     public List<ConfusionMark> getAllConfusionMarksForLecture(int lectureId){
         return mConfusionMarkDao.getAllConfusionMarksForLecture(lectureId);
+    }
+
+    /**
+     * Returns a pair of integers representing the number of resolved (first integer) and unresolved
+     *  (second Integer) ConfusionMarks for a given AcademicClass
+     * @param classId Id for an Academic Class
+     * @return The Pair
+     */
+    public Pair<Integer, Integer> getConfusionMarkResolvedCountForClass(int classId){
+        // No streams with Java 7 :(
+        int numResolved = 0;
+        int numUnresolved = 0;
+        for (ConfusionMark c : this.getAllConfusionMarksForClass(classId)){
+            if (c.getIsResolved()){
+                numResolved++;
+            }
+            else{
+                numUnresolved++;
+            }
+        }
+
+        return new Pair<>(numResolved, numUnresolved);
+    }
+
+    /**
+     * Returns a pair of integers representing the number of resolved (first integer) and unresolved
+     *  (second Integer) ConfusionMarks for a given Lecture
+     * @param lectureId Id for a Lecture
+     * @return The Pair
+     */
+    public Pair<Integer, Integer> getConfusionMarkResolvedCountForLecture(int lectureId){
+        // No streams with Java 7 :(
+        int numResolved = 0;
+        int numUnresolved = 0;
+        for (ConfusionMark c : this.getAllConfusionMarksForLecture(lectureId)){
+            if (c.getIsResolved()){
+                numResolved++;
+            }
+            else{
+                numUnresolved++;
+            }
+        }
+
+        return new Pair<>(numResolved, numUnresolved);
+    }
+
+    /**
+     * Returns a pair of integers representing the number of resolved (first integer) and unresolved
+     *  (second Integer) Notes for a given AcademicClass
+     * @param classId Id for an Academic Class
+     * @return The Pair
+     */
+    public Pair<Integer, Integer> getNoteResolvedCountForClass(int classId){
+        // No streams with Java 7 :(
+        int numResolved = 0;
+        int numUnresolved = 0;
+        for (Note note : this.getAllNotesForClass(classId)){
+            if (note.getIsResolved()){
+                numResolved++;
+            }
+            else{
+                numUnresolved++;
+            }
+        }
+
+        return new Pair<>(numResolved, numUnresolved);
+    }
+
+    /**
+     * Returns a pair of integers representing the number of resolved (first integer) and unresolved
+     *  (second Integer) Notes for a given Lecture
+     * @param lectureId Id for a Lecture
+     * @return The Pair
+     */
+    public Pair<Integer, Integer> getNoteResolvedCountForLecture(int lectureId){
+        // No streams with Java 7 :(
+        int numResolved = 0;
+        int numUnresolved = 0;
+        for (Note note : this.getAllNotesForLecture(lectureId)){
+            if (note.getIsResolved()){
+                numResolved++;
+            }
+            else{
+                numUnresolved++;
+            }
+        }
+
+        return new Pair<>(numResolved, numUnresolved);
     }
 
     /**

--- a/app/src/main/java/com/example/conwayying/query/data/entity/ConfusionMark.java
+++ b/app/src/main/java/com/example/conwayying/query/data/entity/ConfusionMark.java
@@ -34,15 +34,28 @@ public class ConfusionMark {
     @ColumnInfo(name = "end_datetime")
     private Date mEndDate;
 
+    // The Lecture that this ConfusionMark was made for
     @ForeignKey(entity = Lecture.class, parentColumns = "lecture_id", childColumns = "lecture_id")
     @NonNull
     @ColumnInfo(name = "lecture_id")
     private int mLectureId;
 
+    // Boolean indicating whether this ConfusionMark is resolved or not (e.g. does the student
+    //  now understand what made him/her confused when they made this ConfusionMark)
+    @NonNull
+    @ColumnInfo(name = "is_resolved")
+    private boolean mIsResolved;
+
     /**
      * Represent a confusion mark
      *
-     * To represent an interval of time, use setEndDate()
+     * By default, the endDate and isResolved fields are set to null and false, respectively
+     *
+     * To represent an interval of time, set endDate with setEndDate after calling
+     *  the constructor
+     *
+     * To mark a ConfusionMark as resolved, call setIsResolved()
+     *
      * @param startDate The start date for the confusion mark
      * @param lectureId The id of the lecture that this confusion mark was made for
      */
@@ -50,6 +63,7 @@ public class ConfusionMark {
         this.mStartDate = startDate;
         this.mEndDate = null;
         this.mLectureId = lectureId;
+        this.mIsResolved = false;
     }
 
     /**
@@ -90,5 +104,13 @@ public class ConfusionMark {
 
     public void setLectureId(int mLectureId) {
         this.mLectureId = mLectureId;
+    }
+
+    public boolean getIsResolved() {
+        return mIsResolved;
+    }
+
+    public void setIsResolved(boolean isResolved) {
+        this.mIsResolved = isResolved;
     }
 }

--- a/app/src/main/java/com/example/conwayying/query/data/entity/Note.java
+++ b/app/src/main/java/com/example/conwayying/query/data/entity/Note.java
@@ -27,13 +27,20 @@ public class Note {
     @ColumnInfo(name = "note_text")
     private String mNoteText;
 
-    // Flag indicating if this note is still private (haven't sent it to lecturer)
+    // Flag indicating if this note is still private (true if haven't sent it to lecturer)
     @NonNull
     @ColumnInfo(name ="is_private")
     private boolean mIsPrivate;
 
+    // Boolean indicating whether this Note is resolved or not (e.g. does the student
+    //  now understand what made him/her confused when they made this Note)
+    @NonNull
+    @ColumnInfo(name = "is_resolved")
+    private boolean mIsResolved;
+
     /**
-     * Construct a new Note. It is automatically set to being private
+     * Construct a new Note. It is automatically set to being private and unresolved
+     *
      * @param lectureId The id of the Lecture this Note is associated with
      * @param noteText The actual text of the note
      */
@@ -41,6 +48,7 @@ public class Note {
         this.mLectureId = lectureId;
         this.mNoteText = noteText;
         this.mIsPrivate = true;
+        this.mIsResolved = false;
     }
 
     public int getNoteId() {
@@ -73,5 +81,13 @@ public class Note {
 
     public void setIsPrivate(boolean mIsPrivate) {
         this.mIsPrivate = mIsPrivate;
+    }
+
+    public boolean getIsResolved() {
+        return mIsResolved;
+    }
+
+    public void setIsResolved(boolean isResolved) {
+        this.mIsResolved = isResolved;
     }
 }

--- a/app/src/main/java/com/example/conwayying/query/data/entity/NoteDao.java
+++ b/app/src/main/java/com/example/conwayying/query/data/entity/NoteDao.java
@@ -37,6 +37,17 @@ public interface NoteDao {
      */
     @Query("UPDATE Note SET note_text = :noteText WHERE note_id = :noteId")
     void setNoteText(int noteId, String noteText);
+
+    /**
+     * @param classId Id of the AcademicClass you want to retrieve all ConfusionMarks for
+     * @return The ConfusionMarks for all Lectures that associated with a specified AcademicClass
+     */
+    @Query(
+            "SELECT *" +
+            "FROM Note " +
+            "WHERE Note.lecture_id IN (SELECT Lecture.lecture_id FROM Lecture WHERE Lecture.class_id = :classId)"
+    )
+    List<Note> getAllNotesOfClass(int classId);
 }
 
 


### PR DESCRIPTION
… with some comments. Added methods to QueryAppRepository to get the current number of resolved/unresolved notes/confusion marks on a per-lecture or per-class basis with tests. Updated database version to version 6.